### PR TITLE
Pointer miss error

### DIFF
--- a/library/androidndkgif/jni/GifDecoder.cpp
+++ b/library/androidndkgif/jni/GifDecoder.cpp
@@ -250,7 +250,7 @@ bool GifDecoder::skip(DataBlock* dataBlock)
 bool GifDecoder::readBlock(DataBlock* dataBlock, uint8_t* blockSize)
 {
 	dataBlock->read(blockSize, 1);
-	return blockSize <= 0 || dataBlock->read(block, *blockSize);
+	return *blockSize <= 0 || dataBlock->read(block, *blockSize);
 }
 
 bool GifDecoder::readNetscapeExt(DataBlock* dataBlock)


### PR DESCRIPTION
포인터가 가리키는 값을 비교해야 하는데 포인터 주소값을 비교하고 있습니다.