### PR TITLE
첫프레임 투명 배경에 잔상이 생기는 이슈

### DIFF
--- a/library/androidndkgif/jni/GifDecoder.cpp
+++ b/library/androidndkgif/jni/GifDecoder.cpp
@@ -496,6 +496,7 @@ void GifDecoder::setPixels(uint32_t* act)
 {
 	int32_t pixelNum = width * height;
 	uint32_t* dest = new uint32_t[pixelNum];
+	memset(dest, 0, pixelNum * 4);
 	// fill in starting image contents based on last image's dispose code
 	if (lastDispose > 0) {
 		if (lastDispose == 3) {


### PR DESCRIPTION
메모리  할당 이후 초기화가 되어있지 않아 생기는 문제로보임.